### PR TITLE
Callbacks when time jumps

### DIFF
--- a/rclpy/rclpy/clock.py
+++ b/rclpy/rclpy/clock.py
@@ -16,6 +16,8 @@ from enum import IntEnum
 
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 
+from .duration import Duration
+
 
 class ClockType(IntEnum):
     """
@@ -27,6 +29,90 @@ class ClockType(IntEnum):
     ROS_TIME = 1
     SYSTEM_TIME = 2
     STEADY_TIME = 3
+
+
+class ClockChange(IntEnum):
+
+    # ROS time is active and will continue to be active
+    ROS_TIME_NO_CHANGE = 1
+    # ROS time is being activated
+    ROS_TIME_ACTIVATED = 2
+    # ROS TIME is being deactivated, the clock will report system time after the jump
+    ROS_TIME_DEACTIVATED = 3
+    # ROS time is inactive and the clock will keep reporting system time
+    SYSTEM_TIME_NO_CHANGE = 4
+
+
+class JumpThreshold:
+
+    def __init__(self, *, min_forward, min_backward, on_clock_change=True):
+        """
+        Initialize an instance of JumpThreshold.
+
+        :param min_forward: Minimum jump forwards to be considered exceeded, or None.
+        :param min_backward: Negative duration indicating minimum jump backwards to be considered
+                             exceeded, or None.
+        :param on_clock_change: True to make a callback happen when ROS_TIME is activated
+                                or deactivated.
+        """
+        self.min_forward = min_forward
+        self.min_backward = min_backward
+        self.on_clock_change = on_clock_change
+
+
+class TimeJump:
+
+    def __init__(self, clock_change, delta):
+        if not isinstance(clock_change, ClockChange):
+            raise TypeError('clock_change must be an instance of rclpy.clock.ClockChange')
+        self._clock_change = clock_change
+        self._delta = delta
+
+    @property
+    def clock_change(self):
+        return self._clock_change
+
+    @property
+    def delta(self):
+        return self._delta
+
+
+class JumpHandle:
+
+    def __init__(self, *, clock, threshold, pre_callback, post_callback):
+        """
+        Register a clock jump callback.
+
+        :param clock: Clock that time jump callback is registered to
+        :param pre_callback: Callback to be called before new time is set.
+        :param post_callback: Callback to be called after new time is set, accepting a dictionary
+            with keys "clock_change" and "delta".
+        """
+        if pre_callback is None and post_callback is None:
+            raise ValueError('One of pre_callback or post_callback must be callable')
+        if pre_callback is not None and not callable(pre_callback):
+            raise ValueError('pre_callback must be callable if given')
+        if post_callback is not None and not callable(post_callback):
+            raise ValueError('post_callback must be callable if given')
+        self._clock = clock
+        self._pre_callback = pre_callback
+        self._post_callback = post_callback
+
+        min_forward = 0
+        if threshold.min_forward is not None:
+            min_forward = threshold.min_forward.nanoseconds
+        min_backward = 0
+        if threshold.min_backward is not None:
+            min_backward = threshold.min_backward.nanoseconds
+
+        _rclpy.rclpy_add_clock_callback(
+            clock, self, threshold.on_clock_change, min_forward, min_backward)
+
+    def unregister(self):
+        """Remove a jump callback from the clock."""
+        if self._clock is not None:
+            _rclpy.rclpy_remove_clock_callback(self._clock, self)
+            self._clock = None
 
 
 class Clock:
@@ -56,6 +142,44 @@ class Clock:
         return Time(
             nanoseconds=_rclpy.rclpy_time_point_get_nanoseconds(time_handle),
             clock_type=self.clock_type)
+
+    def create_jump_callback(self, threshold, *, pre_callback=None, post_callback=None):
+        """
+        Create callback handler for clock time jumps.
+
+        The callbacks must remain valid as long as the returned JumpHandler is valid.
+        A callback should execute as quick as possible and must not block when called.
+        If a callback raises then no time jump callbacks added after it will be called.
+
+        :param threshold: Criteria for activating time jump.
+        :param pre_callback: Callback to be called before new time is set.
+        :param post_callback: Callback to be called after new time is set accepting
+        :rtype: :class:`rclpy.clock.JumpHandler`
+        """
+        if post_callback is not None and callable(post_callback):
+            original_callback = post_callback
+
+            def callback_shim(jump_dict):
+                nonlocal original_callback
+                clock_change = None
+                if 'RCL_ROS_TIME_NO_CHANGE' == jump_dict['clock_change']:
+                    clock_change = ClockChange.ROS_TIME_NO_CHANGE
+                elif 'RCL_ROS_TIME_ACTIVATED' == jump_dict['clock_change']:
+                    clock_change = ClockChange.ROS_TIME_ACTIVATED
+                elif 'RCL_ROS_TIME_DEACTIVATED' == jump_dict['clock_change']:
+                    clock_change = ClockChange.ROS_TIME_DEACTIVATED
+                elif 'RCL_SYSTEM_TIME_NO_CHANGE' == jump_dict['clock_change']:
+                    clock_change = ClockChange.SYSTEM_TIME_NO_CHANGE
+                else:
+                    raise ValueError('Unknown clock jump type ' + repr(clock_change))
+                duration = Duration(nanoseconds=jump_dict['delta'])
+                original_callback(TimeJump(clock_change, duration))
+
+            post_callback = callback_shim
+
+        return JumpHandle(
+            clock=self._clock_handle, threshold=threshold, pre_callback=pre_callback,
+            post_callback=post_callback)
 
 
 class ROSClock(Clock):

--- a/rclpy/test/test_time_source.py
+++ b/rclpy/test/test_time_source.py
@@ -14,12 +14,16 @@
 
 import time
 import unittest
+from unittest.mock import Mock
 
 import builtin_interfaces.msg
 import rclpy
 from rclpy.clock import Clock
+from rclpy.clock import ClockChange
 from rclpy.clock import ClockType
+from rclpy.clock import JumpThreshold
 from rclpy.clock import ROSClock
+from rclpy.duration import Duration
 from rclpy.time import Time
 from rclpy.time_source import CLOCK_TOPIC
 from rclpy.time_source import TimeSource
@@ -45,6 +49,17 @@ class TestTimeSource(unittest.TestCase):
             cycle_count += 1
             rclpy.spin_once(self.node, timeout_sec=1)
             # TODO(dhood): use rate once available
+            time.sleep(1)
+
+    def publish_reversed_clock_messages(self):
+        clock_pub = self.node.create_publisher(builtin_interfaces.msg.Time, CLOCK_TOPIC)
+        cycle_count = 0
+        time_msg = builtin_interfaces.msg.Time()
+        while rclpy.ok() and cycle_count < 5:
+            time_msg.sec = 6 - cycle_count
+            clock_pub.publish(time_msg)
+            cycle_count += 1
+            rclpy.spin_once(self.node, timeout_sec=1)
             time.sleep(1)
 
     def test_time_source_attach_clock(self):
@@ -123,3 +138,100 @@ class TestTimeSource(unittest.TestCase):
         node2.destroy_node()
         assert time_source._node == node2
         assert time_source._clock_sub is not None
+
+    def test_forwards_jump(self):
+        time_source = TimeSource(node=self.node)
+        clock = ROSClock()
+        time_source.attach_clock(clock)
+        time_source.ros_time_is_active = True
+
+        pre_cb = Mock()
+        post_cb = Mock()
+        threshold = JumpThreshold(
+            min_forward=Duration(seconds=0.5), min_backward=None, on_clock_change=False)
+        handler = clock.create_jump_callback(
+            threshold, pre_callback=pre_cb, post_callback=post_cb)
+
+        self.publish_clock_messages()
+
+        pre_cb.assert_called()
+        post_cb.assert_called()
+        assert post_cb.call_args[0][0].clock_change == ClockChange.ROS_TIME_NO_CHANGE
+        handler.unregister()
+
+    def test_backwards_jump(self):
+        time_source = TimeSource(node=self.node)
+        clock = ROSClock()
+        time_source.attach_clock(clock)
+        time_source.ros_time_is_active = True
+
+        pre_cb = Mock()
+        post_cb = Mock()
+        threshold = JumpThreshold(
+            min_forward=None, min_backward=Duration(seconds=-0.5), on_clock_change=False)
+        handler = clock.create_jump_callback(
+            threshold, pre_callback=pre_cb, post_callback=post_cb)
+
+        self.publish_reversed_clock_messages()
+
+        pre_cb.assert_called()
+        post_cb.assert_called()
+        assert post_cb.call_args[0][0].clock_change == ClockChange.ROS_TIME_NO_CHANGE
+        handler.unregister()
+
+    def test_clock_change(self):
+        time_source = TimeSource(node=self.node)
+        clock = ROSClock()
+        time_source.attach_clock(clock)
+        time_source.ros_time_is_active = True
+
+        pre_cb = Mock()
+        post_cb = Mock()
+        threshold = JumpThreshold(min_forward=None, min_backward=None, on_clock_change=True)
+        handler = clock.create_jump_callback(
+            threshold, pre_callback=pre_cb, post_callback=post_cb)
+
+        time_source.ros_time_is_active = False
+        pre_cb.assert_called()
+        post_cb.assert_called()
+        assert post_cb.call_args[0][0].clock_change == ClockChange.ROS_TIME_DEACTIVATED
+
+        pre_cb.reset_mock()
+        post_cb.reset_mock()
+
+        time_source.ros_time_is_active = True
+        pre_cb.assert_called()
+        post_cb.assert_called()
+        assert post_cb.call_args[0][0].clock_change == ClockChange.ROS_TIME_ACTIVATED
+        handler.unregister()
+
+    def test_no_pre_callback(self):
+        time_source = TimeSource(node=self.node)
+        clock = ROSClock()
+        time_source.attach_clock(clock)
+        time_source.ros_time_is_active = True
+
+        post_cb = Mock()
+        threshold = JumpThreshold(min_forward=None, min_backward=None, on_clock_change=True)
+        handler = clock.create_jump_callback(
+            threshold, pre_callback=None, post_callback=post_cb)
+
+        time_source.ros_time_is_active = False
+        post_cb.assert_called_once()
+        assert post_cb.call_args[0][0].clock_change == ClockChange.ROS_TIME_DEACTIVATED
+        handler.unregister()
+
+    def test_no_post_callback(self):
+        time_source = TimeSource(node=self.node)
+        clock = ROSClock()
+        time_source.attach_clock(clock)
+        time_source.ros_time_is_active = True
+
+        pre_cb = Mock()
+        threshold = JumpThreshold(min_forward=None, min_backward=None, on_clock_change=True)
+        handler = clock.create_jump_callback(
+            threshold, pre_callback=pre_cb, post_callback=None)
+
+        time_source.ros_time_is_active = False
+        pre_cb.assert_called_once()
+        handler.unregister()


### PR DESCRIPTION
Recreated from original PR: https://github.com/ros2/rclpy/pull/222

This adds callbacks when ROSTime jumps. The implementation closely mimics the implementation in `rclcpp`.

Time jump callbacks use the `rcl_clock_t` time jump callbacks. Python code is called in the callbacks using `PyObject_CallObject()`.

Requires ros2/rcl#284